### PR TITLE
Fix to work with new WP API

### DIFF
--- a/appthemes-updater.php
+++ b/appthemes-updater.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: AppThemes Updater
 Description: Allows customers to automatically update AppThemes Products.
-Version: 1.2.1
+Version: 1.3
 Author: AppThemes
 Author URI: http://appthemes.com
 AppThemes ID: appthemes-updater

--- a/appthemes-updater.pot
+++ b/appthemes-updater.pot
@@ -1,43 +1,28 @@
-# Copyright (C) 2012 AppThemes Updater
+# Copyright (C) 2013 AppThemes Updater
 # This file is distributed under the same license as the AppThemes Updater package.
 msgid ""
 msgstr ""
-"Project-Id-Version: AppThemes Updater 1.2.1\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/tag/appthemes-updater\n"
-"POT-Creation-Date: 2012-10-07 16:48:11+00:00\n"
+"Project-Id-Version: AppThemes Updater 1.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-10-27 10:41+0100\n"
+"PO-Revision-Date: 2013-10-27 10:42+0100\n"
+"Last-Translator: AppThemes\n"
+"Language-Team: AppThemes\n"
+"Language: English\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2012-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 1.5.7\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_nx:1,2;_x:1,2c;_ex:1,2c;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:1,2,3c\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: .\n"
+"X-Poedit-SearchPath-0: .\n"
 
-#: templates/admin-page.php:3
-msgid "AppThemes API Key"
-msgstr ""
-
-#: templates/admin-page.php:6
-msgid "Copy the key found at %1$s and paste it in the field below:"
-msgstr ""
-
-#: templates/admin-page.php:13
-msgid "Save"
-msgstr ""
-
-#: templates/check-for-updates.php:1
-msgid "Check for updates now"
-msgstr ""
-
-#: templates/notice.php:2
-msgid "The AppThemes Updater is almost ready."
-msgstr ""
-
-#: templates/notice.php:3
-msgid ""
-"You must <a href=\"%1$s\">enter your AppThemes API key</a> for it to work."
-msgstr ""
-
-#: updater-class.php:157
+#: updater-class.php:240
+#, php-format
 msgid ""
 "<strong>IMPORTANT</strong>: If you have made any modifications to the "
 "AppThemes files, they will be overwritten if you proceed with the automatic "
@@ -54,9 +39,39 @@ msgstr ""
 msgid "AppThemes Updater Configuration"
 msgstr ""
 
-#. #-#-#-#-#  appthemes-updater.pot (AppThemes Updater 1.1.2)  #-#-#-#-#
-#. Plugin Name of the plugin/theme
 #: updater-ui.php:70 updater-ui.php:98
+msgid "AppThemes Updater"
+msgstr ""
+
+#: templates/admin-page.php:3
+msgid "AppThemes API Key"
+msgstr ""
+
+#: templates/admin-page.php:6
+#, php-format
+msgid "Copy the key found at %1$s and paste it in the field below:"
+msgstr ""
+
+#: templates/admin-page.php:13
+msgid "Save"
+msgstr ""
+
+#: templates/api-key-notice.php:2
+msgid "The AppThemes Updater is almost ready."
+msgstr ""
+
+#: templates/api-key-notice.php:3
+#, php-format
+msgid ""
+"You must <a href=\"%1$s\">enter your AppThemes API key</a> for it to work."
+msgstr ""
+
+#: templates/check-for-updates.php:1
+msgid "Check for updates now"
+msgstr ""
+
+#. #-#-#-#-#  appthemes-updater.pot (AppThemes Updater 1.3)  #-#-#-#-#
+#. Plugin Name of the plugin/theme
 msgid "AppThemes Updater"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: scribu, appthemes
 Tags: multisite, network, plugins, themes, updates
 Requires at least: 3.4
-Tested up to: 3.6
+Tested up to: 3.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,6 +14,10 @@ With this plugin, you can receive automatic updates for themes and plugins
 from AppThemes.
 
 == Changelog ==
+
+= 1.3 =
+* fixed compatibility with WordPress 3.7
+* fixed not finding updates when only one theme is installed
 
 = 1.2.1 =
 * fixed not finding updates


### PR DESCRIPTION
- fixes Updater to work with new WP API
- fixes issue with one theme present in WP

See LH:
- https://appthemes.lighthouseapp.com/projects/96270/tickets/28-wp-37-api-changes-to-json
- https://appthemes.lighthouseapp.com/projects/96270/tickets/29-at-least-one-more-theme-is-required

@chacha could you please review and test it? Would be nice if you look also on our API fixes: https://github.com/AppThemes/appthemes.com/pull/2
